### PR TITLE
RDD Graph (json-relay part)

### DIFF
--- a/src/main/scala/org/apache/spark/JsonRelay.scala
+++ b/src/main/scala/org/apache/spark/JsonRelay.scala
@@ -79,7 +79,7 @@ class JsonRelay(conf: SparkConf) extends SparkFirehoseListener {
     }
 
     // Parse `SparkListenerJobStart` event to extract DAG, it is converted into JSON string,
-    // 'appId' and event as 'SparkListenerDAG' are added
+    // 'appId' and event as 'SparkListenerSubmitDAG' are added
     val maybeDAGs: Seq[String] = event match {
       case jobStart: SparkListenerJobStart => jobStart.stageInfos.map { stageInfo =>
         compact(OperationGraph.makeJsonStageDAG(stageInfo) ~

--- a/src/main/scala/org/apache/spark/JsonRelay.scala
+++ b/src/main/scala/org/apache/spark/JsonRelay.scala
@@ -82,7 +82,7 @@ class JsonRelay(conf: SparkConf) extends SparkFirehoseListener {
     // 'appId' and event as 'SparkListenerSubmitDAG' are added
     val maybeDAGs: Seq[String] = event match {
       case jobStart: SparkListenerJobStart => jobStart.stageInfos.map { stageInfo =>
-        compact(OperationGraph.makeJsonStageDAG(stageInfo) ~
+        compact(OperationGraph.makeJsonStageDAG(stageInfo, jobStart.jobId) ~
           ("appId" -> appId) ~ ("Event" -> "SparkListenerSubmitDAG"))
       }
       case otherEvent => Seq.empty

--- a/src/main/scala/org/apache/spark/ui/OperationGraph.scala
+++ b/src/main/scala/org/apache/spark/ui/OperationGraph.scala
@@ -1,0 +1,44 @@
+package org.apache.spark.ui
+
+import org.apache.spark.scheduler.{SparkListenerJobStart, StageInfo}
+import org.apache.spark.ui.scope._
+
+import org.json4s.JsonDSL._
+import org.json4s.JsonAST.JObject
+
+/**
+ * [[OperationGraph]] is used to convert [[RDDOperationGraph]] or [[StageInfo]]
+ * into JSON object, in case of latter also adds stage id and attempt id.
+ * Currently `node.callsite` is not supported to keep compatibility with Spark 1.5.x
+ */
+object OperationGraph {
+  private val graph = RDDOperationGraph
+
+  /** Convert cluster into JSON object, currently `callsite` attribute is not exported */
+  private def makeJsonCluster(cluster: RDDOperationCluster): JObject = {
+    val childNodes = cluster.childNodes.map { node =>
+      ("id" -> node.id) ~ ("name" -> node.name) ~ ("label" -> s"${node.name} [${node.id}]") ~
+        ("cached" -> node.cached) }
+    val clusters = cluster.childClusters.map(makeJsonCluster)
+    ("id" -> cluster.id) ~ ("name" -> cluster.name) ~ ("childNodes" -> childNodes) ~
+      ("clusters" -> clusters)
+  }
+
+  /** Convert RDDOperationGraph into JSON, this includes root cluster and edges */
+  def makeJson(dag: RDDOperationGraph): JObject = {
+    // make subclusters
+    val clustersJson = ("rootCluster" -> makeJsonCluster(dag.rootCluster))
+    // make edges
+    val edgesJson = ("edges" -> dag.edges.map { edge =>
+      ("fromId" -> edge.fromId) ~ ("toId" -> edge.toId)
+    })
+    edgesJson ~ clustersJson
+  }
+
+  /** Convert StageInfo into JSON, this includes stage id and attempt id */
+  def makeJsonStageDAG(stageInfo: StageInfo): JObject = {
+    val dag = OperationGraph.graph.makeOperationGraph(stageInfo)
+    val dagJson = makeJson(dag)
+    ("stageId" -> stageInfo.stageId) ~ ("attemptId" -> stageInfo.attemptId) ~ dagJson
+  }
+}

--- a/src/main/scala/org/apache/spark/ui/OperationGraph.scala
+++ b/src/main/scala/org/apache/spark/ui/OperationGraph.scala
@@ -22,15 +22,22 @@ object OperationGraph {
     ("rddId" -> node.id) ~ ("name" -> node.name) ~ ("cached" -> node.cached)
   }
 
-  /** Convert StageInfo dot file into JSON, this includes stage id and attempt id */
-  def makeJsonStageDAG(stageInfo: StageInfo): JObject = {
+  /**
+   * Convert StageInfo dot file into JSON, this includes job/stage/attempt id, plus all
+   * necessary metadata to replicate RDD graph for job/stage similar to Spark UI.
+   * @param stageInfo stage info
+   * @param jobId job id for stage info
+   * @return JSON object representing RDD graph by dot file, incoming/outgoing edges, cached rdds
+   */
+  def makeJsonStageDAG(stageInfo: StageInfo, jobId: Int): JObject = {
     val dag = OperationGraph.graph.makeOperationGraph(stageInfo)
     val dotFile = OperationGraph.graph.makeDotFile(dag)
     val outgoingEdges = dag.outgoingEdges.map(edgeToJson)
     val incomingEdges = dag.incomingEdges.map(edgeToJson)
+    val skipped = dag.rootCluster.name.contains("skipped")
     val cachedNodes = dag.rootCluster.getCachedNodes.map(nodeToJson)
-    ("stageId" -> stageInfo.stageId) ~ ("attemptId" -> stageInfo.attemptId) ~
-      ("dotFile" -> dotFile) ~ ("cachedRDDs" -> cachedNodes) ~
+    ("jobId" -> jobId) ~ ("stageId" -> stageInfo.stageId) ~ ("attemptId" -> stageInfo.attemptId) ~
+      ("dotFile" -> dotFile) ~ ("cachedRDDs" -> cachedNodes) ~ ("skipped" -> skipped) ~
         ("incomingEdges" -> incomingEdges) ~ ("outgoingEdges" -> outgoingEdges)
   }
 }


### PR DESCRIPTION
This PR adds functionality to store RDD graph as JSON. 
Uses dot files, incoming/outgoing edges, cached RDDs similar to Spark `UIUtils`.

Adds following events:
- `SparkListenerGraphSubmit` - graph for stage is submitted
- `SparkListenerGraphUpdate` - graph for stage is updated (`submitted = true`)
- `SparkListenerGraphCheck` - child for stage is updated (`childSubmitted = true`)

Combinations of these types allow us to mark skipped stages.

Should be merged with similar PR in `slim` and `spree`.
